### PR TITLE
Use -version instead of --version

### DIFF
--- a/src/lib/java.js
+++ b/src/lib/java.js
@@ -11,7 +11,7 @@ function executeJar (options) {
 
   const bareJavaExecutable = command.split(' ').shift()
   try {
-    execSync(`${bareJavaExecutable} --version`, {
+    execSync(`${bareJavaExecutable} -version`, {
       stdio: 'ignore'
     })
   } catch (err) {


### PR DESCRIPTION
When checking availability of the java command use -version instead of --version
to make it work with java 1.8, which only supports -version. Newer java versions support
both -version (prints product version to the output stream and exits.) and --version
(prints product version to the error stream and exits.).

https://docs.oracle.com/en/java/javase/11/tools/java.html